### PR TITLE
Introduce fallback to default block view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ezsystems/ezpublish-kernel": "^6.3",
-    "ezsystems/landing-page-fieldtype-bundle": "~1.3"
+    "ezsystems/landing-page-fieldtype-bundle": ">=1.3 <=1.7"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/lib/HelperObject/Block.php
+++ b/lib/HelperObject/Block.php
@@ -34,7 +34,7 @@ class Block
         $this->id = $this->generateId($block['@id']);
         $this->name = $block['name'];
         $this->type  = $block['type'];
-        $this->view = $block['view'];
+        $this->view = isset($block['view']) && !empty($block['view']) ? $block['view'] : 'default';
         $this->overflow = isset($block['overflow_id']) && !empty($block['overflow_id']) ? $this->generateId($block['overflow_id']) : null;
         $this->attributes = isset($block['custom_attributes']) ? $block['custom_attributes'] : [];
         


### PR DESCRIPTION
This PR introduces a fallback to `default` block view in case when there is no block's view defined in the XML stored in database. 

Besides that, this PR changes `composer.json` to restrict usage of this package to eZ Platform v1.7.x LTS only, since it depends on `EzSystems\LandingPageFieldTypeBundle\FieldType\LandingPage\Model\Block\Item` which has been removed in `EzLandingPageFieldTypeBundle` 1.10. 

