### PR TITLE
Improvements and fixes necessary to perform migration from eZ Flow to eZ Studio

### DIFF
--- a/bundle/Command/EzFlowMigrateCommand.php
+++ b/bundle/Command/EzFlowMigrateCommand.php
@@ -128,13 +128,8 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
 
                 $landingPage = $page->getLandingPage($configuration);
 
-                if ($landingPage) {
-                    Report::write("Save page as Landing Page");
-                    $legacyModel->updateEzPage($legacyPage['id'], $landingPage);
-                }
-                else {
-                    Report::write("Not valid page field (empty or used as call-to-action). Ignoring...");
-                }
+                Report::write('Save page as Landing Page');
+                $legacyModel->updateEzPage($legacyPage['id'], $landingPage);
             }
 
             $legacyModel->replacePageFieldType();

--- a/bundle/Command/EzFlowMigrateCommand.php
+++ b/bundle/Command/EzFlowMigrateCommand.php
@@ -141,9 +141,8 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
                 'services' => [],
             ];
 
-            $this->handler->beginTransaction();
-
             try {
+                $this->handler->beginTransaction();
                 foreach ($legacyPages as $legacyPage) {
                     Report::write('Migrating page...');
                     Report::write("ContentId: {$legacyPage['contentobject_id']}, FieldId: {$legacyPage['id']}, Version: {$legacyPage['version']}");
@@ -158,12 +157,11 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
                 }
 
                 $legacyModel->replacePageFieldType();
+                $this->handler->commit();
             } catch (\Exception $e) {
                 $this->handler->rollBack();
                 throw $e;
             }
-
-            $this->handler->commit();
 
             $path = 'src/MigrationBundle/Resources/config';
             $filesystem->mkdir($path);

--- a/bundle/Command/EzFlowMigrateCommand.php
+++ b/bundle/Command/EzFlowMigrateCommand.php
@@ -10,20 +10,34 @@ use EzSystems\EzFlowMigrationToolkit\Report;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Dumper;
 
 class EzFlowMigrateCommand extends ContainerAwareCommand
 {
-    /** @var DatabaseHandler $handler */
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
+     */
     private $handler;
+
+    /**
+     * @var \EzSystems\LandingPageFieldTypeBundle\Registry\BlockTypeRegistry
+     */
+    private $blockTypeRegistry;
+
+    /**
+     * @var \EzSystems\LandingPageFieldTypeBundle\FieldType\LandingPage\XmlConverter
+     */
+    private $xmlConverter;
+
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
 
     protected function configure()
     {
@@ -42,6 +56,14 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
         );
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->handler = $this->getContainer()->get('ezpublish.api.storage_engine.legacy.dbhandler');
+        $this->blockTypeRegistry = $this->getContainer()->get('ezpublish.landing_page.registry.block_type');
+        $this->xmlConverter = $this->getContainer()->get('ezpublish.fieldtype.ezlandingpage.xml_converter');
+        $this->twig = $this->getContainer()->get('twig');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $filesystem = new Filesystem();
@@ -54,7 +76,7 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
 
             $filesystem->mkdir('src/MigrationBundle');
             
-            Report::write("Migrtion log: src/MigrationBundle/migration.log");
+            Report::write('Migration log: src/MigrationBundle/migration.log');
 
             $warning = new OutputFormatterStyle('yellow', 'red', array('bold', 'blink'));
             $output->getFormatter()->setStyle('warning', $warning);
@@ -101,7 +123,7 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
             $legacyCustomConfiguration = $input->getOption('ini');
 
             Wrapper::initialize($legacyPath, $legacyCustomConfiguration ?: []);
-            Wrapper::$handler = $this->getContainer()->get('ezpublish.api.storage_engine.legacy.dbhandler');
+            Wrapper::$handler = $this->handler;
 
             $legacyWrapper = new Wrapper();
 
@@ -111,7 +133,7 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
             $legacyPages = $legacyModel->getPages();
 
             Report::write('Reading legacy block configuration');
-            $blockMapper = new BlockMapper($legacyWrapper->getBlockConfiguration(), $this->getContainer()->get('twig'));
+            $blockMapper = new BlockMapper($legacyWrapper->getBlockConfiguration(), $this->twig);
 
             $configuration = [
                 'layouts' => [],
@@ -119,20 +141,29 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
                 'services' => [],
             ];
 
-            foreach ($legacyPages as $legacyPage) {
-                Report::write("Migrating page...");
-                Report::write("ContentId: {$legacyPage['contentobject_id']}, FieldId: {$legacyPage['id']}, Version: {$legacyPage['version']}");
+            $this->handler->beginTransaction();
 
-                $legacyPage['name'] = 'Migrated Landing Page';
-                $page = new Page($legacyPage, $this->getContainer(), $blockMapper);
+            try {
+                foreach ($legacyPages as $legacyPage) {
+                    Report::write('Migrating page...');
+                    Report::write("ContentId: {$legacyPage['contentobject_id']}, FieldId: {$legacyPage['id']}, Version: {$legacyPage['version']}");
 
-                $landingPage = $page->getLandingPage($configuration);
+                    $legacyPage['name'] = 'Migrated Landing Page';
+                    $page = new Page($legacyPage, $this->xmlConverter, $this->blockTypeRegistry, $blockMapper);
 
-                Report::write('Save page as Landing Page');
-                $legacyModel->updateEzPage($legacyPage['id'], $landingPage);
+                    $landingPage = $page->getLandingPage($configuration);
+
+                    Report::write('Save page as Landing Page');
+                    $legacyModel->updateEzPage($legacyPage['id'], $landingPage);
+                }
+
+                $legacyModel->replacePageFieldType();
+            } catch (\Exception $e) {
+                $this->handler->rollBack();
+                throw $e;
             }
 
-            $legacyModel->replacePageFieldType();
+            $this->handler->commit();
 
             $path = 'src/MigrationBundle/Resources/config';
             $filesystem->mkdir($path);
@@ -157,7 +188,7 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
 
                 $filesystem->dumpFile(
                     "{$path}/{$layout['identifier']}.html.twig",
-                    $this->getContainer()->get('twig')->render('@EzFlowMigrationToolkit/twig/layout.html.twig', [
+                    $this->twig->render('@EzFlowMigrationToolkit/twig/layout.html.twig', [
                         'zones' => $layout['zones']
                     ])
                 );
@@ -170,19 +201,19 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
             Report::write("Save layout configuration: {$path}/layouts.yml");
             $filesystem->dumpFile("{$path}/layouts.yml", $layoutYaml);
 
-            Report::write("Prepare PHP classes for MigrationBundle");
+            Report::write('Prepare PHP classes for MigrationBundle');
             $filesystem->dumpFile(
-                "src/MigrationBundle/MigrationBundle.php",
-                $this->getContainer()->get('twig')->render('@EzFlowMigrationToolkit/php/MigrationBundle.php.twig')
+                'src/MigrationBundle/MigrationBundle.php',
+                $this->twig->render('@EzFlowMigrationToolkit/php/MigrationBundle.php.twig')
             );
             $filesystem->dumpFile(
-                "src/MigrationBundle/DependencyInjection/MigrationExtension.php",
-                $this->getContainer()->get('twig')->render('@EzFlowMigrationToolkit/php/Extension.php.twig')
+                'src/MigrationBundle/DependencyInjection/MigrationExtension.php',
+                $this->twig->render('@EzFlowMigrationToolkit/php/Extension.php.twig')
             );
 
-            Report::write("Done!");
+            Report::write('Done!');
 
-            $output->writeln($formatter->formatBlock(["  Success!  "], 'info'));
+            $output->writeln($formatter->formatBlock(['  Success!  '], 'info'));
         }
         catch (\Exception $e) {
             $message = "ERROR: {$e->getMessage()}";

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "repositories": [
     { "type": "composer", "url": "https://updates.ez.no/ttl" }
   ],
-  "license": "TTL-2.0",
+  "license": "GPL-2.0-only",
   "autoload": {
     "psr-4": {
       "EzSystems\\EzFlowMigrationToolkit\\": "lib",

--- a/lib/HelperObject/Page.php
+++ b/lib/HelperObject/Page.php
@@ -21,26 +21,35 @@ class Page
 
     private $zones = [];
 
+    /**
+     * @var string
+     */
     private $xml;
 
     private $blockMapper;
 
-    private $container;
-
     private $name = 'Legacy';
 
+    /**
+     * @var \EzSystems\LandingPageFieldTypeBundle\FieldType\LandingPage\XmlConverter
+     */
     private $xmlConverter;
+
+    /**
+     * @var \EzSystems\LandingPageFieldTypeBundle\Registry\BlockTypeRegistry
+     */
+    private $blockTypeRegistry;
 
     public function __construct(
         $ezpage,
-        $container,
+        $xmlConverter,
+        $blockTypeRegistry,
         $blockMapper
     ) {
         $this->xml = $ezpage['data_text'];
         $this->blockMapper = $blockMapper;
-        $this->container = $container;
-
-        $this->xmlConverter = $this->container->get('ezpublish.fieldtype.ezlandingpage.xml_converter');
+        $this->xmlConverter = $xmlConverter;
+        $this->blockTypeRegistry = $blockTypeRegistry;
 
         $serializer = new Serializer([new ObjectNormalizer()], [new XmlEncoder()]);
 
@@ -101,7 +110,7 @@ class Page
                 new LandingPage(
                     $this->getName(),
                     self::DEFAULT_LAYOUT,
-                    new LandingZone(self::DEFAULT_ZONE_ID, self::DEFAULT_ZONE_NAME)
+                    [new LandingZone(self::DEFAULT_ZONE_ID, self::DEFAULT_ZONE_NAME)]
                 )
             );
         }
@@ -137,8 +146,7 @@ class Page
                     
                     $blockDefinition = $this->blockMapper->generateBlockClass($block->getType());
 
-                    $blockRegistry = $this->container->get('ezpublish.landing_page.registry.block_type');
-                    $blockRegistry->addBlockType('legacy_'.strtolower($block->getType()), $blockDefinition);
+                    $this->blockTypeRegistry->addBlockType('legacy_'.strtolower($block->getType()), $blockDefinition);
 
                     $studioBlock = new BlockValue(
                         $block->getId(),

--- a/lib/Legacy/Model.php
+++ b/lib/Legacy/Model.php
@@ -86,15 +86,15 @@ class Model
                 $update->bindValue('ezlandingpage', null, PDO::PARAM_STR)
             )
             ->where(
-                $update->expr->eq(
-                    $this->handler->quoteColumn('data_type_string', 'ezcontentclass_attribute'),
-                    $update->bindValue('ezpage', null, PDO::PARAM_STR)
-                )
-            )
-            ->where(
-                $update->expr->eq(
-                    $this->handler->quoteColumn('identifier', 'ezcontentclass_attribute'),
-                    $update->bindValue('page', null, PDO::PARAM_STR)
+                $update->expr->lOr(
+                    $update->expr->eq(
+                        $this->handler->quoteColumn('data_type_string', 'ezcontentclass_attribute'),
+                        $update->bindValue('ezpage', null, PDO::PARAM_STR)
+                    ),
+                    $update->expr->eq(
+                        $this->handler->quoteColumn('identifier', 'ezcontentclass_attribute'),
+                        $update->bindValue('page', null, PDO::PARAM_STR)
+                    )
                 )
             );
 

--- a/lib/Legacy/Model.php
+++ b/lib/Legacy/Model.php
@@ -59,6 +59,10 @@ class Model
                 $this->handler->quoteColumn('data_text', 'ezcontentobject_attribute'),
                 $update->bindValue($xml, null, PDO::PARAM_STR)
             )
+            ->set(
+                $this->handler->quoteColumn('data_type_string', 'ezcontentobject_attribute'),
+                $update->bindValue('ezlandingpage', null, PDO::PARAM_STR)
+            )
             ->where(
                 $update->expr->eq(
                     $this->handler->quoteColumn('id', 'ezcontentobject_attribute'),


### PR DESCRIPTION
This PR introduces missing replacement of the values in `ezcontentobject_attribute` column. With these changes, `data_type_string` will be changed from `ezpage`/`page` to `ezlandingpage` what is necessary for further migration to PageBuilder (ref: https://github.com/ezsystems/ezplatform-page-migration/blob/master/src/bundle/Command/MigrateDataCommand.php#L250)

Besides that, the PR contains few fixes including proper replacement of `ezpage` in `ezcontentclass_attribute` and introduces transactions for migration to avoid database inconsistencies in case of failure. 

Moreover, I did small clean-up like avoiding injecting the whole Container in the loop. 

There are much more things to improve in this package, but as for now what it's done is enough to cover most of the cases of migration. 

If time permits, the next step will be to modify package to make it work with 1.13. 