### PR TITLE
Fixed composer requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ For help text: `app/console ezflow:migrate --help`
 
 This packge does not yet allow migration to 2.x (Page builder) directly, to do that you'll need to migrate in two stages:
 1. From eZ Flow to 1.7LTS _(Landing Pages)_, using this package.
-2. From 1.13LTS to 2.5LTS _(Page builder)_ using [ezsystems/ezplatform-page-migration](https://github.com/ezsystems/ezplatform-page-migration) package.
+2. From 1.7LTS to 2.5LTS _(Page builder)_ using [ezsystems/ezplatform-page-migration](https://github.com/ezsystems/ezplatform-page-migration) package.

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ For help text: `app/console ezflow:migrate --help`
 # Todo: Migration to v2
 
 This packge does not yet allow migration to 2.x (Page builder) directly, to do that you'll need to migrate in two stages:
-1. From eZ Flow to 1.7LTS _(Landig Pages)_, using this package.
+1. From eZ Flow to 1.7LTS _(Landing Pages)_, using this package.
 2. From 1.13LTS to 2.5LTS _(Page builder)_ using [ezsystems/ezplatform-page-migration](https://github.com/ezsystems/ezplatform-page-migration) package.

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ For help text: `app/console ezflow:migrate --help`
 # Todo: Migration to v2
 
 This packge does not yet allow migration to 2.x (Page builder) directly, to do that you'll need to migrate in two stages:
-1. From eZ Flow to 1.13LTS _(Landig Pages)_, using this package.
+1. From eZ Flow to 1.7LTS _(Landig Pages)_, using this package.
 2. From 1.13LTS to 2.5LTS _(Page builder)_ using [ezsystems/ezplatform-page-migration](https://github.com/ezsystems/ezplatform-page-migration) package.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ezsystems/ezpublish-kernel": "^6.3",
-    "ezsystems/landing-page-fieldtype-bundle": ">=1.3 1.7.*"
+    "ezsystems/landing-page-fieldtype-bundle": "~1.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ezsystems/ezpublish-kernel": "^6.3",
-    "ezsystems/landing-page-fieldtype-bundle": ">=1.3 <=1.7"
+    "ezsystems/landing-page-fieldtype-bundle": ">=1.3 1.7.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"


### PR DESCRIPTION
This PR fixes incorrect version constraint. `<=1.7` means *not higher than 1.7.0* which is incorrect since we allow all of the `1.7` branch versions. 