### PR TITLE
Make it possble to run the migration on 2.5

### DIFF
--- a/bundle/Command/EzFlowMigrateCommand.php
+++ b/bundle/Command/EzFlowMigrateCommand.php
@@ -163,7 +163,7 @@ class EzFlowMigrateCommand extends ContainerAwareCommand
 
                     Report::write('Save page as Landing Page');
                     if (!$dryRun) {
-                        $legacyModel->updateEzPage($legacyPage['id'], $landingPage);
+                        $legacyModel->updateEzPage($legacyPage['id'], $legacyPage['version'], $landingPage);
                     }
                 }
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ezsystems/ezpublish-kernel": "^7.5",
-    "ezsystems/landing-page-fieldtype-bundle": "~1.7.0"
+    "ezsystems/landing-page-fieldtype-bundle": "dev-ezflow_migration"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   },
   "require": {
-    "ezsystems/ezpublish-kernel": "^6.3",
+    "ezsystems/ezpublish-kernel": "^7.5",
     "ezsystems/landing-page-fieldtype-bundle": "~1.7.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ezsystems/ezpublish-kernel": "^7.5",
-    "ezsystems/landing-page-fieldtype-bundle": "dev-ezflow_migration"
+    "ezsystems/landing-page-fieldtype-bundle": "1.7.7-alpha1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/lib/HelperObject/Block.php
+++ b/lib/HelperObject/Block.php
@@ -24,6 +24,8 @@ class Block
     
     private $overflow;
     
+    private $ttl;
+
     public function __construct($block, $blockMapper)
     {
         $model = new Model(Wrapper::$handler);
@@ -36,6 +38,7 @@ class Block
         $this->type  = $block['type'];
         $this->view = isset($block['view']) && !empty($block['view']) ? $block['view'] : 'default';
         $this->overflow = isset($block['overflow_id']) && !empty($block['overflow_id']) ? $this->generateId($block['overflow_id']) : null;
+        $this->ttl = isset($block['ttl']) && !empty($block['ttl']) ? $block['ttl'] : '0';
         $this->attributes = isset($block['custom_attributes']) ? $block['custom_attributes'] : [];
         
         if (isset($block['overflow_id']) && !empty($block['overflow_id'])) {
@@ -86,6 +89,11 @@ class Block
         return $this->overflow;
     }
     
+    public function getTtl()
+    {
+        return $this->ttl;
+    }
+
     public function hasOverflow()
     {
         return (bool)$this->overflow;
@@ -96,3 +104,4 @@ class Block
         return 'b-' . UUID::v3(Wrapper::getUuidSeed(), $legacyId);
     }
 }
+

--- a/lib/HelperObject/Page.php
+++ b/lib/HelperObject/Page.php
@@ -148,11 +148,20 @@ class Page
 
                     $this->blockTypeRegistry->addBlockType('legacy_'.strtolower($block->getType()), $blockDefinition);
 
+                    $blockAttributes = $block->getAttributes();
+                    if (is_string($blockAttributes)) {
+                        if ($blockAttributes === '') {
+                            $blockAttributes = array();
+                            Report::write("Attribute for block {$block->getType()} was empty string. Converted to empty array");
+                        } else {
+                            throw new \Exception("Unknown attribute format for block {$block->getType()}. Attribute value : $blockAttributes");
+                        }
+                    }
                     $studioBlock = new BlockValue(
                         $block->getId(),
                         'legacy_' . strtolower($block->getType()),
                         $block->getView(),
-                        $block->getAttributes()
+                        $blockAttributes
                     );
 
                     Report::write("Generate service configuration for new block type");

--- a/lib/HelperObject/Page.php
+++ b/lib/HelperObject/Page.php
@@ -56,7 +56,7 @@ class Page
         try {
             $page = new PageValue();
             
-            if ($this->xml) {
+            if ($this->xml && $this->xml !== "<?xml version=\"1.0\"?>\n<page/>\n") {
                 $page = $serializer->deserialize($this->xml, 'EzSystems\EzFlowMigrationToolkit\HelperObject\PageValue', 'xml');
             }
         }

--- a/lib/HelperObject/Page.php
+++ b/lib/HelperObject/Page.php
@@ -170,6 +170,7 @@ class Page
                 }
 
                 $studioBlock->setName($block->getName());
+                $studioBlock->setTtl($block->getTtl());
 
                 if (!isset($configuration['blocks'][$studioBlock->getType()])) {
                     $configuration['blocks'][$studioBlock->getType()] = [

--- a/lib/Legacy/Model.php
+++ b/lib/Legacy/Model.php
@@ -40,8 +40,7 @@ class Model
                     $this->handler->quoteColumn('data_type_string', 'ezcontentobject_attribute'),
                     $select->bindValue('ezpage', null, PDO::PARAM_STR)
                 )
-            )
-            ->where('data_text IS NOT NULL');
+            );
 
         $query = $select->prepare();
         $query->execute();

--- a/lib/Legacy/Model.php
+++ b/lib/Legacy/Model.php
@@ -48,7 +48,7 @@ class Model
         return $query->fetchAll();
     }
 
-    public function updateEzPage($id, $xml)
+    public function updateEzPage($id, $version, $xml)
     {
         $update = $this->handler->createUpdateQuery();
 
@@ -63,9 +63,13 @@ class Model
                 $update->bindValue('ezlandingpage', null, PDO::PARAM_STR)
             )
             ->where(
-                $update->expr->eq(
-                    $this->handler->quoteColumn('id', 'ezcontentobject_attribute'),
-                    $update->bindValue($id, null, PDO::PARAM_INT)
+                $update->expr->lAnd(
+                    $update->expr->eq(
+                        $this->handler->quoteColumn('id', 'ezcontentobject_attribute'),
+                        $update->bindValue($id, null, PDO::PARAM_INT)),
+                    $update->expr->eq(
+                        $this->handler->quoteColumn('version', 'ezcontentobject_attribute'),
+                        $update->bindValue($version, null, PDO::PARAM_INT))
                 )
 
             );

--- a/lib/Mapper/BlockMapper.php
+++ b/lib/Mapper/BlockMapper.php
@@ -81,6 +81,7 @@ class BlockMapper
         }
 
         $className = '\MigrationBundle\LandingPage\Block\Legacy' . $type . 'Block';
+        require_once $filePath;
 
         return new $className;
     }


### PR DESCRIPTION
This makes it possible to run the migration on 2.5

The actually version dependency to `ezsystems/landing-page-fieldtype-bundle` is dependent on https://github.com/ezsystems/EzLandingPageFieldTypeBundle/pull/217 and what we call that release.